### PR TITLE
Increase EPICS_CA_MAX_ARRAY_BYTES.

### DIFF
--- a/ci-scripts/epics-config.sh
+++ b/ci-scripts/epics-config.sh
@@ -8,7 +8,7 @@ if [ -z "$EPICS_CA_ADDR_LIST" ]; then
 fi
 
 export EPICS_CA_AUTO_ADDR_LIST=NO
-export EPICS_CA_MAX_ARRAY_BYTES=10000000
+export EPICS_CA_MAX_ARRAY_BYTES=1000000000
 
 # V4 network settings
 if [ -z "$EPICS_PVA_ADDR_LIST" ]; then


### PR DESCRIPTION
This moves this patch

https://github.com/caproto/caproto/pull/502/commits/6aa1c3036f5f40662d2f6b24bb59992f9327fa3a

upstream. To see that it is necessary compare this build:

https://travis-ci.org/caproto/caproto/builds/571030872

to this one:

https://travis-ci.org/caproto/caproto/builds/571010202

It seems that the R7 releases work because the `EPICS_CA_MAX_ARRAY_BYTES`
setting is *ignored* by default and EPICS tries to "just work". See
https://epics.anl.gov/base/R7-0/2-docs/RELEASE_NOTES.html.